### PR TITLE
fix/ fix base url

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -2,11 +2,11 @@ import { ApiResponse, ApiResponseSchema } from "@/types/crypto";
 
 class ApiService {
   private readonly baseUrl =
-    process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api/cryptos";
+    process.env.NEXT_PUBLIC_API_URL ;
 
   async fetchCryptos(start = 1, limit = 100): Promise<ApiResponse> {
     const response = await fetch(
-      `${this.baseUrl}?start=${start}&limit=${limit}`,
+      `${this.baseUrl}/api/cryptos?start=${start}&limit=${limit}`,
       {
         next: {
           revalidate: 300,


### PR DESCRIPTION
## Summary by Sourcery

Fix base URL configuration and correct the endpoint path for fetching cryptos.

Bug Fixes:
- Remove the default localhost fallback for baseUrl and rely solely on the NEXT_PUBLIC_API_URL environment variable
- Append "/api/cryptos" to the baseUrl when constructing the fetch URL for cryptocurrencies