### PR TITLE
fix/ fix base url for vercel

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -1,18 +1,27 @@
 import { ApiResponse, ApiResponseSchema } from "@/types/crypto";
 
 class ApiService {
-  private readonly baseUrl =
-    process.env.NEXT_PUBLIC_API_URL ;
+  private getBaseUrl(): string {
+    if (process.env.NEXT_PUBLIC_API_URL) {
+      return process.env.NEXT_PUBLIC_API_URL;
+    }
+    
+    if (process.env.VERCEL_URL) {
+      return `https://${process.env.VERCEL_URL}`;
+    }
+    
+    return 'http://localhost:3000';
+  }
 
   async fetchCryptos(start = 1, limit = 100): Promise<ApiResponse> {
-    const response = await fetch(
-      `${this.baseUrl}/api/cryptos?start=${start}&limit=${limit}`,
-      {
-        next: {
-          revalidate: 300,
-        },
-      }
-    );
+    const baseUrl = this.getBaseUrl();
+    const url = `${baseUrl}/api/cryptos?start=${start}&limit=${limit}`;
+    
+    const response = await fetch(url, {
+      next: {
+        revalidate: 300,
+      },
+    });
 
     if (!response.ok) {
       throw new Error(`API Error: ${response.status}`);


### PR DESCRIPTION
## Summary by Sourcery

Fix API base URL resolution in ApiService by introducing fallbacks for VERCEL_URL and localhost and refactor fetch logic to use a centralized getter

Bug Fixes:
- Add fallback to VERCEL_URL or localhost when NEXT_PUBLIC_API_URL is undefined

Enhancements:
- Extract getBaseUrl method to centralize base URL determination
- Refactor fetchCryptos to construct and reuse the URL variable